### PR TITLE
chore: bumping version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qeepsake/react-navigation-overlay",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Don't we all wish that React Navigation had awesome Overlays like React Native Navigation ? Now it does 💪",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bumping version to 1.1.2 to remove `InteractionManager`, since the code inside it wasn't being executed.

Commit with change: https://github.com/Qeepsake/react-navigation-overlay/commit/deac702e040ab482182c4704732b7a2e16b30587